### PR TITLE
Add trailblazer reloaded ornament animationIDs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ dependencies {
 }
 
 group = 'xyz.oelderoth.runelite.forestry'
-version = '1.0.1'
+version = '1.0.2'
 
 tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'

--- a/src/main/java/xyz/oelderoth/runelite/forestry/service/WoodcuttingService.java
+++ b/src/main/java/xyz/oelderoth/runelite/forestry/service/WoodcuttingService.java
@@ -15,7 +15,6 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import net.runelite.api.AnimationID;
 import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
@@ -30,6 +29,7 @@ import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ScriptPreFired;
+import net.runelite.api.gameval.AnimationID;
 import net.runelite.api.gameval.ObjectID;
 import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
@@ -44,7 +44,36 @@ import xyz.oelderoth.runelite.forestry.domain.WoodcuttingStateListener;
 @Singleton
 public class WoodcuttingService
 {
-	private static final Set<Integer> WOODCUTTING_ANIMATION_IDS = Sets.newHashSet(AnimationID.WOODCUTTING_BRONZE, AnimationID.WOODCUTTING_IRON, AnimationID.WOODCUTTING_STEEL, AnimationID.WOODCUTTING_BLACK, AnimationID.WOODCUTTING_MITHRIL, AnimationID.WOODCUTTING_ADAMANT, AnimationID.WOODCUTTING_RUNE, AnimationID.WOODCUTTING_GILDED, AnimationID.WOODCUTTING_DRAGON, AnimationID.WOODCUTTING_DRAGON_OR, AnimationID.WOODCUTTING_INFERNAL, AnimationID.WOODCUTTING_3A_AXE, AnimationID.WOODCUTTING_CRYSTAL, AnimationID.WOODCUTTING_TRAILBLAZER, AnimationID.WOODCUTTING_2H_BRONZE, AnimationID.WOODCUTTING_2H_IRON, AnimationID.WOODCUTTING_2H_STEEL, AnimationID.WOODCUTTING_2H_BLACK, AnimationID.WOODCUTTING_2H_MITHRIL, AnimationID.WOODCUTTING_2H_ADAMANT, AnimationID.WOODCUTTING_2H_RUNE, AnimationID.WOODCUTTING_2H_DRAGON, AnimationID.WOODCUTTING_2H_CRYSTAL, AnimationID.WOODCUTTING_2H_CRYSTAL_INACTIVE, AnimationID.WOODCUTTING_2H_3A);
+	private static final Set<Integer> WOODCUTTING_ANIMATION_IDS = Sets.newHashSet(
+		AnimationID.HUMAN_WOODCUTTING_BRONZE_AXE,
+		AnimationID.HUMAN_WOODCUTTING_IRON_AXE,
+		AnimationID.HUMAN_WOODCUTTING_STEEL_AXE,
+		AnimationID.HUMAN_WOODCUTTING_BLACK_AXE,
+		AnimationID.HUMAN_WOODCUTTING_MITHRIL_AXE,
+		AnimationID.HUMAN_WOODCUTTING_ADAMANT_AXE,
+		AnimationID.HUMAN_WOODCUTTING_RUNE_AXE,
+		AnimationID.HUMAN_WOODCUTTING_GILDED_AXE,
+		AnimationID.HUMAN_WOODCUTTING_DRAGON_AXE,
+		AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_AXE_NO_INFERNAL,
+		AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_RELOADED_AXE_NO_INFERNAL,
+		AnimationID.HUMAN_WOODCUTTING_INFERNAL_AXE,
+		AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_AXE,
+		AnimationID.HUMAN_WOODCUTTING_TRAILBLAZER_RELOADED_AXE,
+		AnimationID.HUMAN_WOODCUTTING_3A_AXE,
+		AnimationID.HUMAN_WOODCUTTING_CRYSTAL_AXE,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_BRONZE,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_IRON,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_STEEL,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_BLACK,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_MITHRIL,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_ADAMANT,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_RUNE,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_DRAGON,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_CRYSTAL,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_CRYSTAL_INACTIVE,
+		AnimationID.FORESTRY_2H_AXE_CHOPPING_3A
+	);
+
 	private static final int TREE_DESPAWNED_LOC_TYPE = 2;
 
 	@Inject


### PR DESCRIPTION
Adding the Trailblazer Reloaded animations to resolve #3 

Also migrating off of the deprecated `net.runelite.api.AnimationID` to the new `net.runelite.api.gameval.AnimationID` constants.